### PR TITLE
Focal length + principal point value fix

### DIFF
--- a/apriltags_ros/include/apriltags_ros/apriltag_detector.h
+++ b/apriltags_ros/include/apriltags_ros/apriltag_detector.h
@@ -41,6 +41,7 @@ class AprilTagDetector{
   ros::Publisher pose_pub_;
   tf::TransformBroadcaster tf_pub_;
   boost::shared_ptr<AprilTags::TagDetector> tag_detector_;
+  bool projected_optics_;
 };
 
 

--- a/apriltags_ros/launch/example.launch
+++ b/apriltags_ros/launch/example.launch
@@ -10,6 +10,10 @@
     <!-- Select the tag family: 16h5, 25h7, 25h9, 36h9, or 36h11(default) -->
     <param name="tag_family" type="str" value="36h11" />
 
+    <!-- Enable projected optical measurements for more accurate tag transformations -->
+    <!-- This exists for backwards compatability and should be left true for new setups -->
+    <param name="projected_optics" type="bool" value="true" />
+
     <!-- Describe the tags -->
     <rosparam param="tag_descriptions">[
       {id: 0, size: 0.163513},

--- a/apriltags_ros/src/apriltag_detector.cpp
+++ b/apriltags_ros/src/apriltag_detector.cpp
@@ -80,10 +80,10 @@ void AprilTagDetector::imageCb(const sensor_msgs::ImageConstPtr& msg,const senso
   std::vector<AprilTags::TagDetection>	detections = tag_detector_->extractTags(gray);
   ROS_DEBUG("%d tag detected", (int)detections.size());
 
-  double fx = cam_info->K[0];
-  double fy = cam_info->K[4];
-  double px = cam_info->K[2];
-  double py = cam_info->K[5];
+  double fx = cam_info->P[0];
+  double fy = cam_info->P[5];
+  double px = cam_info->P[2];
+  double py = cam_info->P[6];
 
   if(!sensor_frame_id_.empty())
     cv_ptr->header.frame_id = sensor_frame_id_;


### PR DESCRIPTION
Fixes a bug discovered by @jpapon in #11 where the node uses incorrect optical measurements for calculating tag transformations.
For backwards compatibility, I've implemented it such that the fix needs to be manually enabled via a `projected_optics` parameter.

@velinddimitrov thoughts?
