### PR TITLE
fix misplaced 'using namespace std'

### DIFF
--- a/apriltags/include/AprilTags/TagFamily.h
+++ b/apriltags/include/AprilTags/TagFamily.h
@@ -8,7 +8,6 @@
 #include <map>
 
 #include "AprilTags/TagDetection.h"
-using namespace std;
 
 namespace AprilTags {
 

--- a/apriltags/src/TagFamily.cc
+++ b/apriltags/src/TagFamily.cc
@@ -22,6 +22,7 @@ TagFamily *tag36h11 = new TagFamily(tagCodes36h11);
 
 */
 
+using namespace std;
 
 namespace AprilTags {
 


### PR DESCRIPTION
Fix issue https://github.com/RIVeR-Lab/apriltags_ros/issues/25

Warning, those who had included this may suddenly fail to compile if they were implicitly depending on the accidental namespace dump