### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/apriltags_ros/src/apriltag_detector_nodelet.cpp
+++ b/apriltags_ros/src/apriltag_detector_nodelet.cpp
@@ -23,4 +23,4 @@ private:
 
 }
 
-PLUGINLIB_DECLARE_CLASS(apriltags_ros, AprilTagDetectorNodelet, apriltags_ros::AprilTagDetectorNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(apriltags_ros::AprilTagDetectorNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions